### PR TITLE
Add DDB Access Permissions

### DIFF
--- a/mountain-ui-api/serverless.yml
+++ b/mountain-ui-api/serverless.yml
@@ -50,6 +50,12 @@ provider:
           Resource:
             - arn:aws:s3:::mountain-ui-app-slopes-unzipped
             - arn:aws:s3:::mountain-ui-app-slopes-unzipped/*
+        - Effect: Allow
+          Action:
+            - dynamodb:*
+          Resource:
+            - arn:aws:dynamodb:::table/mountain-ui-app-users
+            - arn:aws:dynamodb:::table/mountain-ui-app-users/*
 
 functions:
   graphql:


### PR DESCRIPTION
Error:

```
2023-04-24T05:58:11.804Z	69ef5c68-9c96-4cfb-b8a6-100cf7f5ac9b	ERROR	AccessDeniedException: User: arn:aws:sts::170267588697:assumed-role/mountain-ui-api-production-us-west-1-lambdaRole/mountain-ui-api-production-graphql is not authorized to perform: dynamodb:PutItem on resource: arn:aws:dynamodb:us-west-1:170267588697:table/mountain-ui-app-users because no identity-based policy allows the dynamodb:PutItem action
    at throwDefaultError (/var/task/node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/smithy-client/dist-cjs/default-error-handler.js:8:22)
    at /var/task/node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/smithy-client/dist-cjs/default-error-handler.js:18:39
    at de_PutItemCommandError (/var/task/node_modules/@aws-sdk/client-dynamodb/dist-cjs/protocols/Aws_json1_0.js:1899:20)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async /var/task/node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-serde/dist-cjs/deserializerMiddleware.js:7:24
    at async /var/task/node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-signing/dist-cjs/middleware.js:14:20
    at async /var/task/node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-retry/dist-cjs/retryMiddleware.js:27:46
    at async /var/task/node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-logger/dist-cjs/loggerMiddleware.js:7:26
    at async putItem (/var/task/src/aws/dynamodb.js:60:16)
    at async Object.createUser (/var/task/src/resolvers/Mutation/createUser.js:7:5) {
  '$fault': 'client',
  '$metadata': {
    httpStatusCode: 400,
    requestId: 'P9U865J1FDESB2K4E32B5I4ISVVV4KQNSO5AEMVJF66Q9ASUAAJG',
    extendedRequestId: undefined,
    cfId: undefined,
    attempts: 1,
    totalRetryDelay: 0
  },
  __type: 'com.amazon.coral.service#AccessDeniedException'
}
```